### PR TITLE
Fix output plugin's boolean value handler condition in template telegraf.conf

### DIFF
--- a/templates/telegraf.conf.j2
+++ b/templates/telegraf.conf.j2
@@ -95,7 +95,7 @@
 {% endif %}
 {% else %}
 {% if value == "true" or value == "false" or value is number %}
-    {{ key }} = {{ value }}
+    {{ key }} = {{ value | lower }}
 {% else %}
     {{ key }} = "{{ value }}"
 {% endif %}


### PR DESCRIPTION
Add lower filter to value in output plugin's boolean handler condition
Since the current code will treat boolean (or even quoted boolean such as `"false"`) in `telegraf_output_plugins` as Python boolean (`True` and `False` with the first letter capitalized) which violates telegraf configuration
This fix ensures the first letter in value will be converted to lowercase